### PR TITLE
Removed iolib dependency

### DIFF
--- a/restas-directory-publisher.asd
+++ b/restas-directory-publisher.asd
@@ -12,6 +12,6 @@
 (in-package #:restas-directory-publisher-system)
 
 (defsystem restas-directory-publisher
-  :depends-on (#:restas #:closure-template #:local-time #:iolib.syscalls #+sbcl :hunchentoot-cgi)
+  :depends-on (#:restas #:closure-template #:local-time #+sbcl :hunchentoot-cgi)
   :components ((:module "src"
                         :components ((:file "directory-publisher")))))


### PR DESCRIPTION
While installing restas-directory-publisher with quicklisp it installs iolib. It prevents from using this lib (via quicklisp) on win32. Iolib dependency is not used inside lib an can be safely removed.
